### PR TITLE
Fix a bug in child()

### DIFF
--- a/R/offspring.R
+++ b/R/offspring.R
@@ -9,7 +9,7 @@
 ##' child(x, 4)
 child.tbl_tree <- function(.data, .node, ...) {
     valid.tbl_tree(.data)
-    subset(.data, .data$parent == .node & .data$parent != .data$node)
+    .data[.data$parent == .node & .data$parent != .data$node,]
 }
 
 ##' @method offspring tbl_tree

--- a/R/offspring.R
+++ b/R/offspring.R
@@ -9,17 +9,7 @@
 ##' child(x, 4)
 child.tbl_tree <- function(.data, .node, ...) {
     valid.tbl_tree(.data)
-    ## filter_(.data, ~(parent == .node | label == .node) & node != parent)
-
-    ndata <- .data[which(.data$node == .node | .data$label == .node), ]
-    .node <- ndata$node
-
-    i <- which(.data$parent == .node & .data$parent != .data$node)
-    if (length(i) == 0) {
-        ## tip
-        return(.data[0,])
-    }
-    .data[i,]
+    subset(.data, .data$parent == .node & .data$parent != .data$node)
 }
 
 ##' @method offspring tbl_tree


### PR DESCRIPTION
The old version fails when `.data$label` contains numeric characters like `'6'`
because `isTRUE('6' == 6)` in R, and it causes superfluous match.
Now `.node` argument must be always numeric and compared with `.data$parent`.

```r
library(tidytree)
library(ape)
set.seed(2017)
tree = rtree(4)
x = as_tibble(tree)
y = x %>% dplyr::mutate(label = as.character(sample.int(length(node))))
child(y, 6)
```

Output from the current version:
```
Warning in .data$parent == .node :
  longer object length is not a multiple of shorter object length
Calls: child -> child.tbl_tree -> which
Empty data.table (0 rows) of 4 cols: parent,node,branch.length,label
```

Output from the fixed version:
```
   parent  node branch.length  label
    <int> <int>         <num> <char>
1:      6     3     0.6743315      6
2:      6     7     0.4349056      7
```