### PR TITLE
fix an warning when the data and extraInfo all is empty

### DIFF
--- a/R/as-tibble.R
+++ b/R/as-tibble.R
@@ -80,6 +80,10 @@ get_tree_data <- function(tree_object) {
     tree_anno <- tree_object@data
     extraInfo <- tree_object@extraInfo
 
+    if (nrow(tree_anno)==0 && nrow(extraInfo)==0){
+        return(NULL)
+    }
+
     if (nrow(tree_anno) == 0) {
         extraInfo$node <- as.integer(extraInfo$node)
         return(extraInfo)


### PR DESCRIPTION
when data and extraInfo of treedata object are empty, a warning will generate via `as_tibble`.

