### PR TITLE
Use `inject()` to splice in dots

### DIFF
--- a/R/left-join.R
+++ b/R/left-join.R
@@ -8,14 +8,15 @@ left_join.treedata <- function(x, y, by = NULL, copy = FALSE, ...){
     }
 
     dat <- .extract_annotda.treedata(x)
-    ornm <- colnames(dat) 
-    da <- dat %>%
-          dplyr::left_join(y, by = by, copy = copy, suffix = suffix, !!!dots)
+    ornm <- colnames(dat)
+    da <- rlang::inject(
+      dplyr::left_join(dat, y, by = by, copy = copy, suffix = suffix, !!!dots)
+    )
 
     if (any(duplicated(da$node))){
         da %<>% .internal_nest(keepnm=ornm)
     }
-    
+
     tr <- .update.td.join(td=x, da=da)
     return(tr)
 }


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`left_join()` has never supported dynamic dots (i.e. you can't use `!!!dots`), and the new version of dplyr checks that the dots are empty, so what you were doing before was an error. To do this correctly you need to wrap it in `inject()`.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!