### PR TITLE
control whether print the message when tbl_tree to not tbl_df

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -44,11 +44,12 @@ setGeneric("get.data", function(object, ...) standardGeneric("get.data"))
 ##' @title groupOTU
 ##' @param .data tree object (phylo, treedata, tbl_tree, ggtree etc.)
 ##' @param .node selected nodes
+##' @param group_name character the name of the group cluster, default is \code{group}.
 ##' @param ... additional parameter
 ##' @return updated tree with group information or group index
 ##' @author Guangchuang Yu
 ##' @export
-groupOTU <- function(.data, .node, ...) {
+groupOTU <- function(.data, .node, group_name = 'group', ...) {
     UseMethod("groupOTU")
 }
 
@@ -57,10 +58,12 @@ groupOTU <- function(.data, .node, ...) {
 ##'
 ##' @title groupClade
 ##' @inheritParams groupOTU
+##' @param overlap character one of \code{overwrite},\code{origin} and \code{abandon},
+##' default is \code{overwrite}.
 ##' @return updated tree with group information or group index
 ##' @author Guangchuang Yu
 ##' @export
-groupClade <- function(.data, .node, ...) {
+groupClade <- function(.data, .node, group_name = 'group', overlap = 'overwrite', ...) {
     UseMethod("groupClade")
 }
 

--- a/R/ancestor.R
+++ b/R/ancestor.R
@@ -101,14 +101,14 @@ ancestor.tbl_tree <- function(.data, .node, ...) {
 ##' @export
 MRCA.tbl_tree <- function(.data, .node1, .node2 = NULL, ...) {
     if (length(.node1) == 1 && length(.node2) == 1) {
-        return(MRCA.tbl_tree_internal(.data, .node1, .node2, ...))
+        return(.MRCA.tbl_tree_internal(.data, .node1, .node2, ...))
     } else if (is.null(.node2) && length(.node1) >= 1) {
         if (length(.node1) == 1) return(itself(.data, .node1))
         ## else length(.node1) > 1
-        node <- MRCA.tbl_tree_internal(.data, .node1[1], .node1[2])
+        node <- .MRCA.tbl_tree_internal(.data, .node1[1], .node1[2])
         if (length(.node1) > 2) {
             for (i in 3:length(.node1)) {
-                node <- MRCA.tbl_tree_internal(.data, .node1[i], node$node)
+                node <- .MRCA.tbl_tree_internal(.data, .node1[i], node$node)
             }
         }
         return(node)
@@ -119,7 +119,7 @@ MRCA.tbl_tree <- function(.data, .node1, .node2 = NULL, ...) {
 
 #' @noRd
 #' @keywords internal 
-MRCA.tbl_tree_internal <- function(.data, .node1, .node2, ...) {
+.MRCA.tbl_tree_internal <- function(.data, .node1, .node2, ...) {
     anc1 <- ancestor(.data, .node1)
     if (nrow(anc1) == 0) {
         ## .node1 is root

--- a/R/as-tibble.R
+++ b/R/as-tibble.R
@@ -113,7 +113,10 @@ valid.tbl_tree2 <- function(object, cols = c("parent", "node", "label")) {
     if (length(cc) > 0) {
         msg <- paste0("invalid tbl_tree object. Missing column: ", paste(cc, collapse=","), ".")
         msg <- strwrap(style_subtle(msg))
-        message(msg)
+        flag <- getOption(x="check.tbl_tree.verbose", default=TRUE)
+        if (flag){
+           cli::cli_alert_info(msg)
+        }
         return(FALSE)
     }
     if (valid.edge(object)){
@@ -131,7 +134,10 @@ valid.edge <- function(x){
     if (root.num==1 && tip.num > 1 && !any(duplicated(x[,2])) && node.index){
         return(TRUE)
     }else{
-        cli::cli_alert_warning("# Invaild edge matrix for {.cls phylo}. A {.cls tbl_df} is returned.")
+        flag <- getOption(x="check.tbl_tree.verbose", default=TRUE)
+        if (flag){
+            cli::cli_alert_warning("# Invaild edge matrix for {.cls phylo}. A {.cls tbl_df} is returned.")
+        }
         return(FALSE)
     }
 }

--- a/R/groupOTU.R
+++ b/R/groupOTU.R
@@ -8,13 +8,13 @@ groupOTU.tbl_tree <- function(.data, .node,
     .data[[group_name]] <- NULL
     if ( is(.node, "list") ) {
         for (i in seq_along(.node)) {
-            .data <- groupOTU.tbl_tree_item(.data, .node[[i]],
+            .data <- .groupOTU.tbl_tree_item(.data, .node[[i]],
                                             names(.node)[i],
                                             group_name = group_name,
                                             ...)
         }
     } else {
-        .data <- groupOTU.tbl_tree_item(.data, .node,
+        .data <- .groupOTU.tbl_tree_item(.data, .node,
                                         group_name = group_name,
                                         ...)
     }
@@ -31,7 +31,7 @@ groupOTU.tbl_tree <- function(.data, .node,
 ##' @noRd
 ##' @importFrom dplyr group_by
 ##' @keywords internal 
-groupOTU.tbl_tree_item <- function(.data, .node,
+.groupOTU.tbl_tree_item <- function(.data, .node,
                                    focus_label = NULL,
                                    group_name,
                                    overlap="overwrite",

--- a/R/offspring.R
+++ b/R/offspring.R
@@ -29,11 +29,11 @@ offspring.tbl_tree <- function(.data, .node, tiponly = FALSE, self_include = FAL
         stop(".node is required")
     }
     if (length(.node) == 1) {
-        res <- offspring.tbl_tree_item(.data = .data, .node = .node,
+        res <- .offspring.tbl_tree_item(.data = .data, .node = .node,
                                        tiponly = tiponly, self_include = self_include, ...)
     } else {
         res <- lapply(.node, function(node) {
-            offspring.tbl_tree_item(.data = .data, .node = node,
+            .offspring.tbl_tree_item(.data = .data, .node = node,
                                     tiponly = tiponly, self_include = self_include, ...)
         })
         names(res) <- .node
@@ -43,7 +43,7 @@ offspring.tbl_tree <- function(.data, .node, tiponly = FALSE, self_include = FAL
 
 #' @noRd
 #' @keywords internal
-offspring.tbl_tree_item <- function(.data, .node, tiponly = FALSE, self_include = FALSE, ...) {
+.offspring.tbl_tree_item <- function(.data, .node, tiponly = FALSE, self_include = FALSE, ...) {
     x <- child.tbl_tree(.data, .node)
 
     ## https://github.com/GuangchuangYu/ggtree/issues/239

--- a/man/groupClade.Rd
+++ b/man/groupClade.Rd
@@ -4,12 +4,17 @@
 \alias{groupClade}
 \title{groupClade}
 \usage{
-groupClade(.data, .node, ...)
+groupClade(.data, .node, group_name = "group", overlap = "overwrite", ...)
 }
 \arguments{
 \item{.data}{tree object (phylo, treedata, tbl_tree, ggtree etc.)}
 
 \item{.node}{selected nodes}
+
+\item{group_name}{character the name of the group cluster, default is \code{group}.}
+
+\item{overlap}{character one of \code{overwrite},\code{origin} and \code{abandon},
+default is \code{overwrite}.}
 
 \item{...}{additional parameter}
 }

--- a/man/groupOTU.Rd
+++ b/man/groupOTU.Rd
@@ -4,12 +4,14 @@
 \alias{groupOTU}
 \title{groupOTU}
 \usage{
-groupOTU(.data, .node, ...)
+groupOTU(.data, .node, group_name = "group", ...)
 }
 \arguments{
 \item{.data}{tree object (phylo, treedata, tbl_tree, ggtree etc.)}
 
 \item{.node}{selected nodes}
+
+\item{group_name}{character the name of the group cluster, default is \code{group}.}
 
 \item{...}{additional parameter}
 }


### PR DESCRIPTION
This RP control whether print the message when `tbl_tree` is changed to `tbl_df`.  Because the data of `ggtree` is also `tbl_tree` class. But when using `td_filter` in `geom`. many messages will be printed.

```
> p <- taxa.tree %>% ggtree(layout='circ') + geom_hilight(data = td_filter(nodeClass=='Phylum'), aes(fill = label, node=node)) + geom_point(data=td_filter(nodeClass=='Class'))
! # Invaild edge matrix for <phylo>. A <tbl_df> is returned.
! # Invaild edge matrix for <phylo>. A <tbl_df> is returned.
! # Invaild edge matrix for <phylo>. A <tbl_df> is returned.
! # Invaild edge matrix for <phylo>. A <tbl_df> is returned.

> options(check.tbl_tree.verbose=F)
> p <- taxa.tree %>% ggtree(layout='circ') + geom_hilight(data = td_filter(nodeClass=='Phylum'), aes(fill = label, node=node)) + geom_point(data=td_filter(nodeClass=='Class'))
>
```