### PR TITLE
Deduplicating rows of external data in left_join and full_join 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,5 @@ License: Artistic-2.0
 URL: https://yulab-smu.top/contribution-tree-data/
 BugReports: https://github.com/YuLab-SMU/tidytree/issues
 Encoding: UTF-8
-RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
+Config/roxygen2/version: 8.0.0

--- a/R/full-join.R
+++ b/R/full-join.R
@@ -23,8 +23,10 @@ full_join.treedata <- function(x, y, by = NULL,
         cli::cli_warn(msg)
         suffix <- rev(suffix[seq_len(2)])
     }
+
+    y <- .check_duplicated_rows(y)
     
-    da <- dplyr::full_join(dat, dplyr::distinct(y), by = by, copy = copy, suffix = suffix, ...)
+    da <- dplyr::full_join(dat, y, by = by, copy = copy, suffix = suffix, ...)
 
     da <- da[!is.na(da$node),]
 

--- a/R/full-join.R
+++ b/R/full-join.R
@@ -24,7 +24,7 @@ full_join.treedata <- function(x, y, by = NULL,
         suffix <- rev(suffix[seq_len(2)])
     }
     
-    da <- dplyr::full_join(dat, y, by = by, copy = copy, suffix = suffix, ...)
+    da <- dplyr::full_join(dat, dplyr::distinct(y), by = by, copy = copy, suffix = suffix, ...)
 
     da <- da[!is.na(da$node),]
 

--- a/R/left-join.R
+++ b/R/left-join.R
@@ -19,7 +19,7 @@ left_join.treedata <- function(x, y, by = NULL, copy = FALSE, suffix=c("", ".y")
         cli::cli_warn(msg)
         suffix <- rev(suffix[seq_len(2)])
     }
-    da <- dplyr::left_join(dat, y, by = by, copy = copy, suffix = suffix, ...)
+    da <- dplyr::left_join(dat, dplyr::distinct(y), by = by, copy = copy, suffix = suffix, ...)
 
     if (any(duplicated(da$node))){
         da %<>% .internal_nest(keepnm=ornm)

--- a/R/left-join.R
+++ b/R/left-join.R
@@ -19,7 +19,9 @@ left_join.treedata <- function(x, y, by = NULL, copy = FALSE, suffix=c("", ".y")
         cli::cli_warn(msg)
         suffix <- rev(suffix[seq_len(2)])
     }
-    da <- dplyr::left_join(dat, dplyr::distinct(y), by = by, copy = copy, suffix = suffix, ...)
+    y <- .check_duplicated_rows(y)
+
+    da <- dplyr::left_join(dat, y, by = by, copy = copy, suffix = suffix, ...)
 
     if (any(duplicated(da$node))){
         da %<>% .internal_nest(keepnm=ornm)
@@ -67,4 +69,18 @@ left_join.tbl_tree <- function(x, y, by = NULL, copy = FALSE,
         td@extraInfo <- da %>% select(c("node", extra.nm))
     }
     return(td)
+}
+
+.check_duplicated_rows <- function(
+    x, 
+    warning_message='Duplicate rows were deduplicated before joining the tables'
+){
+    flag <- duplicated(x)
+    if (any(flag)){
+        if (!is.null(warning_message)){
+            cli::cli_warn(warning_message)
+        }
+        x <- x[!flag,]
+    }
+    return(x)
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -34,16 +34,16 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{ape}{\code{\link[ape]{as.phylo}}, \code{\link[ape]{as.phylo}}, \code{\link[ape:root]{is.rooted}}, \code{\link[ape:summary.phylo]{Nnode}}, \code{\link[ape:summary.phylo]{Ntip}}, \code{\link[ape]{read.tree}}, \code{\link[ape]{root}}, \code{\link[ape]{rtree}}}
+  \item{ape}{\code{\link[ape:as.phylo]{as.phylo()}}, \code{\link[ape:as.phylo]{as.phylo()}}, \code{\link[ape:is.rooted]{is.rooted()}}, \code{\link[ape:Nnode]{Nnode()}}, \code{\link[ape:Ntip]{Ntip()}}, \code{\link[ape:read.tree]{read.tree()}}, \code{\link[ape:root]{root()}}, \code{\link[ape:rtree]{rtree()}}}
 
-  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr:mutate-joins]{full_join}}, \code{\link[dplyr:mutate-joins]{left_join}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{pull}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{select}}, \code{\link[dplyr]{summarise}}, \code{\link[dplyr:summarise]{summarize}}, \code{\link[dplyr]{transmute}}}
+  \item{dplyr}{\code{\link[dplyr:arrange]{arrange()}}, \code{\link[dplyr:filter]{filter()}}, \code{\link[dplyr:full_join]{full_join()}}, \code{\link[dplyr:left_join]{left_join()}}, \code{\link[dplyr:mutate]{mutate()}}, \code{\link[dplyr:pull]{pull()}}, \code{\link[dplyr:rename]{rename()}}, \code{\link[dplyr:rename]{rename()}}, \code{\link[dplyr:select]{select()}}, \code{\link[dplyr:summarise]{summarise()}}, \code{\link[dplyr:summarize]{summarize()}}, \code{\link[dplyr:transmute]{transmute()}}}
 
-  \item{magrittr}{\code{\link[magrittr:compound]{\%<>\%}}, \code{\link[magrittr:pipe]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:\%<>\%]{\%<>\%}}, \code{\link[magrittr:\%>\%]{\%>\%}}}
 
-  \item{rlang}{\code{\link[rlang:dot-data]{.data}}}
+  \item{rlang}{\code{\link[rlang:.data]{.data}}}
 
-  \item{tibble}{\code{\link[tibble]{as_tibble}}, \code{\link[tibble]{tibble}}}
+  \item{tibble}{\code{\link[tibble:as_tibble]{as_tibble()}}, \code{\link[tibble:tibble]{tibble()}}}
 
-  \item{tidyr}{\code{\link[tidyr]{unnest}}}
+  \item{tidyr}{\code{\link[tidyr:unnest]{unnest()}}}
 }}
 

--- a/man/tidytree-package.Rd
+++ b/man/tidytree-package.Rd
@@ -19,6 +19,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Guangchuang Yu \email{guangchuangyu@gmail.com} (\href{https://orcid.org/0000-0002-6485-8781}{ORCID}) [copyright holder]
 
+Authors:
+\itemize{
+  \item Guangchuang Yu \email{guangchuangyu@gmail.com} (\href{https://orcid.org/0000-0002-6485-8781}{ORCID}) [copyright holder]
+}
+
 Other contributors:
 \itemize{
   \item Bradley Jones \email{brj1@sfu.ca} [contributor]


### PR DESCRIPTION
Duplicate rows were deduplicated before joining the tables

```
> library(tidytree)
tidytree v0.4.7 Learn more at https://yulab-smu.top/contribution-tree-data/

Please cite:

Guangchuang Yu. Using ggtree to visualize data on tree-like structures.
Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96

Attaching package: ‘tidytree’

The following object is masked from ‘package:stats’:

    filter

> library(ggtree)
ggtree v4.2.0 Learn more at https://yulab-smu.top/contribution-tree-data/

Please cite:

S Xu, Z Dai, P Guo, X Fu, S Liu, L Zhou, W Tang, T Feng, M Chen, L
Zhan, T Wu, E Hu, Y Jiang, X Bo, G Yu. ggtreeExtra: Compact
visualization of richly annotated phylogenetic data. Molecular Biology
and Evolution. 2021, 38(9):4039-4042. doi: 10.1093/molbev/msab166
> set.seed(123)
> tr <- rtree(30)
> d <- data.frame(label=tr$tip.label, var1=abs(rnorm(30)), var2=abs(rnorm(30)))
> d2 <- rbind(d, d[1,])
```
## Old version

```
> tr |> dplyr::left_join(d2, by = 'label')
'treedata' S4 object'.

...@ phylo:

Phylogenetic tree with 30 tips and 29 internal nodes.

Tip labels:
  t28, t25, t9, t3, t8, t7, ...

Rooted; includes branch length(s).

with the following features available:
  '', 'var1', 'var2'.

# The associated data tibble abstraction: 59 × 5
# The 'node', 'label' and 'isTip' are from the phylo tree.
    node label isTip var1             var2
   <int> <chr> <lgl> <list>           <list>
 1     1 t28   TRUE  <tibble [2 × 1]> <tibble [2 × 1]>
 2     2 t25   TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 3     3 t9    TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 4     4 t3    TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 5     5 t8    TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 6     6 t7    TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 7     7 t10   TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 8     8 t30   TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
 9     9 t19   TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
10    10 t4    TRUE  <tibble [1 × 1]> <tibble [1 × 1]>
# ℹ 49 more rows
# ℹ Use `print(n = ...)` to see more rows
```
## This PR

```
> tr |> dplyr::left_join(d2, by = 'label')
'treedata' S4 object'.

...@ phylo:

Phylogenetic tree with 30 tips and 29 internal nodes.

Tip labels:
  t28, t25, t9, t3, t8, t7, ...

Rooted; includes branch length(s).

with the following features available:
  '', 'var1', 'var2'.

# The associated data tibble abstraction: 59 × 5
# The 'node', 'label' and 'isTip' are from the phylo tree.
    node label isTip  var1   var2
   <int> <chr> <lgl> <dbl>  <dbl>
 1     1 t28   TRUE  1.69  0.0749
 2     2 t25   TRUE  0.242 0.206
 3     3 t9    TRUE  0.468 0.489
 4     4 t3    TRUE  0.773 0.628
 5     5 t8    TRUE  2.15  0.0469
 6     6 t7    TRUE  1.33  0.163
 7     7 t10   TRUE  0.496 1.29
 8     8 t30   TRUE  1.23  0.464
 9     9 t19   TRUE  0.634 0.305
10    10 t4    TRUE  0.412 0.0840
# ℹ 49 more rows
# ℹ Use `print(n = ...)` to see more rows
Warning message:
Duplicate rows were deduplicated before joining the tables
```